### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,6 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    <link href="{{ config.pluginsConfig.rss.feed_url }}" title="{{ config.pluginsConfig.rss.title }}" rel="alternate" type="application/rss+xml" />
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ export default {
   hooks: {
     // Get and init RSS configuration
     'init': function () {
-      site = this.config.options.pluginsConfig.rss;
+      site = this.config.get('pluginsConfig.rss');
       feed = new RSS(site);
     },
 

--- a/index.js
+++ b/index.js
@@ -29,10 +29,13 @@ export default {
         ? ''
         : page.path.replace(/.md$/,'.html'));
 
+      const pageTitle = title(page.content);
+      const pageDescription = desc(page.content);
+
       feed.item({
-        title: title(page.content).text,
-        description: desc(page.content).text,
-        url,
+        title: pageTitle? pageTitle.text : '',
+        description: pageDescription? pageDescription.text : '',
+        url: url,
         author: site.author
       });
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ export default {
     'finish': function () {
       const xml = feed.xml({ indent: true });
       const feedpath = basename(parse(site.feed_url).pathname);
-      write(resolve(this.options.output, feedpath), xml, 'utf-8');
+      return this.output.writeFile(site.feed_url, xml);
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,10 +11,7 @@ let site, feed;
 export default {
   website: {
     assets: './assets',
-    js: [ 'plugin.js' ],
-    html: {
-      'head:end': () => `<link href="${site.feed_url}" title="${site.title}" rel="alternate"type="application/rss+xml">`
-    }
+    js: [ 'plugin.js' ]
   },
 
   hooks: {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ export default {
     },
 
     // Collect all pages
-    'page': function (page) {
+    'page:before': function (page) {
       // If README.md, then change it to root
       const url = site.site_url +
         ( page.path === 'README.md'


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
It includes the `<link>` tag using templating, uses GitBook 3 native `output.writeFile()` function to write the XML file and makes the plugin a bit more permissive if a chapter doesn't contain a title or a description yet.

Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

You will have to upgrade the engine in your `package.json` for the next release:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
